### PR TITLE
Fix/proposal endpoints tests

### DIFF
--- a/meetupselector/api/routes/proposals.py
+++ b/meetupselector/api/routes/proposals.py
@@ -14,14 +14,17 @@ from meetupselector.proposals.services import ProposalService
 router = Router(auth=django_auth)
 
 
-@router.get("/proposal", response={200: t.List[ProposalListSchema]}, url_name="create_list_proposal", auth=None)
+@router.get(
+    "/proposal",
+    response={200: t.List[ProposalListSchema]},
+    url_name="create_list_proposal",
+    auth=None,
+)
 def list_proposals(request):
     return 200, ProposalService.retrieve_all()
 
 
-@router.post(
-    "/proposal", response={201: ProposalRetrieveSchema}, auth=None
-)
+@router.post("/proposal", response={201: ProposalRetrieveSchema}, auth=None)
 def create_proposal(request, proposal: ProposalCreateSchema):
     return 201, ProposalService.create(**proposal.dict())
 
@@ -46,5 +49,3 @@ def unlike_proposal(request, proposal_id: UUID4):
     user = request.auth
     ProposalService.unlike(proposal_id, user.id)
     return 204, None
-
-    

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -6,9 +6,9 @@ from meetupselector.api.api import api
 
 @pytest.fixture
 def reverse_url():
-    def _reverse_url(function_name: str) -> str:
+    def _reverse_url(function_name: str, kwargs: dict | None = None) -> str:
         api_namespace = api.urls_namespace
 
-        return reverse(f"{api_namespace}:{function_name}")
+        return reverse(f"{api_namespace}:{function_name}", kwargs=kwargs)
 
     return _reverse_url

--- a/tests/api/routes/test_proposals.py
+++ b/tests/api/routes/test_proposals.py
@@ -185,7 +185,6 @@ def test_user_not_authenticated_like_proposal(client):
 @pytest.mark.django_db
 def test_get_list_proposals_exists(client, reverse_url):
     url = reverse_url("create_list_proposal")
-    expected_payload = []
 
     response = client.get(url)
 
@@ -196,13 +195,13 @@ def test_get_list_proposals_exists(client, reverse_url):
 @freeze_time("2022-10-26 23:23:23")
 @pytest.mark.django_db
 def test_list_proposals_endpoint_return_proposals(client, reverse_url):
-    proposal1 = (
+    (
         ProposalBuilder()
         .with_subject("proposal1")
         .with_description("first proposal description")
         .build()
     )
-    proposal2 = (
+    (
         ProposalBuilder()
         .with_subject("proposal2")
         .with_description("second proposal description")

--- a/tests/api/routes/test_proposals.py
+++ b/tests/api/routes/test_proposals.py
@@ -127,8 +127,6 @@ def test_like_proposal(client):
     assert_that(liked_by.first().id, equal_to(fanboy.id))
 
 
-
-
 @freeze_time("2022-10-26 23:23:23")
 @pytest.mark.django_db
 def test_unlike_proposal(client):


### PR DESCRIPTION
- Add kwargs param to reverse_url fixture.
- Apply black code format.
- Refactor tests code to fit Flake8 rules.
- Complete proposal listing endpoint tests


Ticket:
[051 - Añadir el endpoint para listar las propuestas](https://tree.taiga.io/project/aalmiramolla-meetupselector/task/51)