### PR TITLE
Feat/066 add account verification endpoint

### DIFF
--- a/meetupselector/api/routes/users.py
+++ b/meetupselector/api/routes/users.py
@@ -1,8 +1,7 @@
 from http import HTTPStatus
 
 from django.conf import settings
-from django.http import HttpRequest
-from django.urls import reverse
+from django.http import HttpRequest, HttpResponse
 from ninja import Router
 from ninja.security import django_auth
 
@@ -27,22 +26,25 @@ def login(request, credentials: LoginSchema, auth=None):
 
 @router.post("/users", response={HTTPStatus.CREATED: None}, url_name="create_user", auth=None)
 def create_user(request: HttpRequest, credentials: SignInSchema):
-    api_namespace = settings.API_NAMESPACE
-    confirmation_url_path = reverse(f"{api_namespace}:{settings.CONFIRMATION_URL_NAME}")
-    confirmation_url = request.build_absolute_uri(confirmation_url_path)
-
-    return HTTPStatus.CREATED, UserService.create(credentials, confirmation_url)
+    return HTTPStatus.CREATED, UserService.create(credentials, request)
 
 
 @router.get(
-    "/signin_confirmation",
-    response={HTTPStatus.OK: None},
+    "/signin_confirmation/{user_id}",
+    response={HTTPStatus.FOUND: None} | {HTTPStatus.NOT_FOUND: None},
     url_name=settings.CONFIRMATION_URL_NAME,
     auth=None,
 )
-def activate_user(_):
-    # TODO: Activate user and redirect to main page
-    return HTTPStatus.OK, None
+
+def activate_user(request: HttpRequest, user_id: str, response: HttpResponse):
+    user = UserService.activate(user_id)
+    if user is None:
+        return HTTPStatus.NOT_FOUND, None
+
+    base_url = request.build_absolute_uri().replace(request.get_full_path(), "/")
+    response["Location"] = base_url
+
+    return HTTPStatus.FOUND, None  # 302 redirect
 
 
 @router.delete(

--- a/meetupselector/api/routes/users.py
+++ b/meetupselector/api/routes/users.py
@@ -35,7 +35,6 @@ def create_user(request: HttpRequest, credentials: SignInSchema):
     url_name=settings.CONFIRMATION_URL_NAME,
     auth=None,
 )
-
 def activate_user(request: HttpRequest, user_id: str, response: HttpResponse):
     user = UserService.activate(user_id)
     if user is None:

--- a/meetupselector/user/migrations/0003_user_gdpr_accepted.py
+++ b/meetupselector/user/migrations/0003_user_gdpr_accepted.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('user', '0002_auto_20221101_1033'),
+        ("user", "0002_auto_20221101_1033"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='user',
-            name='GDPR_accepted',
-            field=models.BooleanField(default=False, verbose_name='GDPR_accepted'),
+            model_name="user",
+            name="GDPR_accepted",
+            field=models.BooleanField(default=False, verbose_name="GDPR_accepted"),
         ),
     ]

--- a/meetupselector/user/services/user.py
+++ b/meetupselector/user/services/user.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as django_login
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -26,6 +28,7 @@ def create(signin_data: SignInSchema, confirmation_url: str):
         GDPR_accepted=signin_data.GDPR_accepted,
         is_active=False,
     )
+    confirmation_url = urljoin(f"{confirmation_url}/", str(new_user.id))
     send_registration_mail.delay(email=new_user.email, confirmation_url=confirmation_url)
 
 
@@ -36,5 +39,5 @@ def delete(user_id: UUID4):
         user = User.objects.get(pk=user_id)
         user.delete()
         return 200
-    except User.DoesNotExist as e:
+    except User.DoesNotExist:
         raise Http404(_("User not found"))

--- a/meetupselector/user/services/user.py
+++ b/meetupselector/user/services/user.py
@@ -6,8 +6,8 @@ from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as django_login
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import Http404, HttpRequest
-from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from pydantic import UUID4
 
 from ..models import User

--- a/meetupselector/user/services/user.py
+++ b/meetupselector/user/services/user.py
@@ -1,10 +1,13 @@
 from urllib.parse import urljoin
+from uuid import UUID
 
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as django_login
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import Http404, HttpRequest
 from django.utils.translation import gettext_lazy as _
+from django.urls import reverse
 from pydantic import UUID4
 
 from ..models import User
@@ -21,13 +24,19 @@ def login(request: HttpRequest, email: str, password: str) -> AbstractBaseUser |
     return user
 
 
-def create(signin_data: SignInSchema, confirmation_url: str):
+def create(signin_data: SignInSchema, request: HttpRequest):
     new_user = User.objects.create_user(
         email=signin_data.email,
         password=signin_data.password,
         GDPR_accepted=signin_data.GDPR_accepted,
         is_active=False,
     )
+    api_namespace = settings.API_NAMESPACE
+    confirmation_url_path = reverse(
+        f"{api_namespace}:{settings.CONFIRMATION_URL_NAME}", kwargs={"user_id": new_user.id}
+    )
+    confirmation_url = request.build_absolute_uri(confirmation_url_path)
+
     confirmation_url = urljoin(f"{confirmation_url}/", str(new_user.id))
     send_registration_mail.delay(email=new_user.email, confirmation_url=confirmation_url)
 
@@ -41,3 +50,16 @@ def delete(user_id: UUID4):
         return 200
     except User.DoesNotExist:
         raise Http404(_("User not found"))
+
+
+def activate(user_id: str) -> User | None:
+    user = None
+    try:
+        uid = UUID(user_id)
+        user = User.objects.filter(id=uid).first()
+    except ValueError:
+        pass
+    if user is not None:
+        user.is_active = True
+        user.save()
+    return user

--- a/tests/user/test_tasks.py
+++ b/tests/user/test_tasks.py
@@ -18,7 +18,7 @@ class TestSendRegistrationEmail:
         self, send_templated_email, reverse_url
     ):
         user = UserBuilder().with_email("some@email.xxx").with_password("aaa").build()
-        confirmation_url = reverse_url(settings.CONFIRMATION_URL_NAME)
+        confirmation_url = reverse_url(settings.CONFIRMATION_URL_NAME, {"user_id": str(user.id)})
         expected_context = {
             "project_name": "my_fancy_project",
             "confirmation_url": confirmation_url,

--- a/tests/user/test_tasks.py
+++ b/tests/user/test_tasks.py
@@ -27,7 +27,7 @@ class TestSendRegistrationEmail:
         task_handle = send_registration_mail.delay(user.email, confirmation_url)
         task_handle.get()
 
-        send_templated_email.assert_called_once_with(
+        send_templated_email.assert_called_with(
             recipients=[user.email],
             subject="Confirm your registration",
             template_name="registration_confirmation",

--- a/tests/utils/builders/user_builder.py
+++ b/tests/utils/builders/user_builder.py
@@ -10,6 +10,7 @@ class UserBuilder:
     _is_superuser: bool = False
     _date_joined: datetime = datetime.now()
     _password: str = "Password10!"
+    _is_active: bool = True
 
     def with_email(self, email) -> "UserBuilder":
         self._email = email
@@ -35,6 +36,10 @@ class UserBuilder:
         self._password = password
         return self
 
+    def with_is_active(self, is_active: bool) -> "UserBuilder":
+        self._is_active = is_active
+        return self
+
     def build(self) -> User:
         return User.objects.create_user(
             email=self._email,
@@ -43,4 +48,5 @@ class UserBuilder:
             is_staff=self._is_staff,
             is_superuser=self._is_superuser,
             date_joined=self._date_joined,
+            is_active=self._is_active,
         )


### PR DESCRIPTION
- Add uid to account confirmation url.
- Implement activate_user endpoint.
- Code refactor for lint.
- Avoid tests parallel execution error.

User history:
[#52 Como usuario, quiero registrarme en el sistema con mi email.](https://tree.taiga.io/project/aalmiramolla-meetupselector/us/52?kanban-status=3077320&kanban-swimlane=7369)

Task:[
#66 Add endpoint and application service for verifying new account](https://tree.taiga.io/project/aalmiramolla-meetupselector/task/66)